### PR TITLE
feat: [Security] User's full name shouldn't show in Private Group Chat

### DIFF
--- a/app/ui-flextab/client/tabs/userInfo.html
+++ b/app/ui-flextab/client/tabs/userInfo.html
@@ -29,14 +29,12 @@
 							<div class="rc-user-info__avatar">
 								{{> avatar username=username}}
 							</div>
-							<h3 title="{{name}}" class="rc-user-info__name"><i class="status-{{status}}"></i> {{name}}</h3>
 							{{#if username}}<p class="rc-user-info__username">@{{username}}</p>{{/if}}
 							<span class="rc-header__status rc-user-info__status">
 								<div class="rc-header__status-bullet rc-header__status-bullet--{{userStatus}}" title="{{_ userStatus}}"></div>
 								<div class="rc-header__visual-status">{{userStatusText}}</div>
 							</span>
 						</div>
-
 						<div class="rc-user-info-action">
 							{{#each actions}}
 								<button class="js-action rc-user-info-action__item">


### PR DESCRIPTION
Due to the fact that we can invite anybody into our group chat even though the user doesn't have connection within the group which might cause the security risk.

So, for security reason, we don't want to expose the user's real name when view user information.